### PR TITLE
Events updated

### DIFF
--- a/zql-backend/interpreter/grammar.py
+++ b/zql-backend/interpreter/grammar.py
@@ -14,6 +14,7 @@ INCOMPLETE = 'incomplete'
 def parse_sentence(sentence, root_rule):
     parser = ParserPython(root_rule)
     res = {
+        'input': sentence,
         'rule': None,
         'status': None,
         'properties': {},

--- a/zql-backend/interpreter/server.py
+++ b/zql-backend/interpreter/server.py
@@ -5,10 +5,9 @@ import generate
 
 from flask import Flask, jsonify, request
 
+
 app = Flask(__name__)
 
-def persist(sentence, parsed_result):
-    app.logger.info('Parsed properties:', parsed_result['properties'])
 
 @app.route('/keywords')
 def keywords():
@@ -24,14 +23,14 @@ def annotation():
     sentence.
     """
     data = request.json
-    sentence = data['raw']
+    sentence = data['input']
 
     root = generate.get_grammar_root()
     parsed_result = grammar.parse_sentence(sentence, root)
 
     app.logger.info('Parsed sentence:"{}" status:{}'.format(sentence, parsed_result['status']))
     if parsed_result['status'] == grammar.ACCEPT:
-        persist(sentence, parsed_result)
+        app.logger.info('Parsed properties:', parsed_result['properties'])
 
     resp = jsonify(parsed_result)
     resp.headers['Access-Control-Allow-Origin'] = '*'

--- a/zql-backend/post_processing/handler.py
+++ b/zql-backend/post_processing/handler.py
@@ -68,6 +68,13 @@ class GetEventsHandler(BaseHandler):
     view_name = 'get_events'
     methods = ['GET']
 
+    EVENT_OUTPUT_FIELDS = [
+        'created_at',
+        'user_id',
+        'properties',
+        'rule',
+    ]
+
     def __init__(self, mongo):
         """
         @param mongo: mongo client
@@ -88,7 +95,7 @@ class GetEventsHandler(BaseHandler):
         events = []
         predicted = None
         for event in cursor:
-            event['_id'] = str(event['_id'])
+            event = {f: event[f] for f in self.EVENT_OUTPUT_FIELDS}
 
             if event.get('predicted', False):
                 assert not predicted

--- a/zql-backend/post_processing/handler.py
+++ b/zql-backend/post_processing/handler.py
@@ -106,7 +106,8 @@ class GetEventsHandler(BaseHandler):
         if user_id is None:
             return jsonify([])
 
-        cursor = self.mongo.db.events.find({'user_id': user_id}).sort('created_at', pymongo.DESCENDING)
+        query = {'$or': [{'user_id': user_id}, {'author': user_id}]}
+        cursor = self.mongo.db.events.find(query).sort('created_at', pymongo.DESCENDING)
         events = []
         predicted = None
         for event in cursor:

--- a/zql-backend/post_processing/jobs.py
+++ b/zql-backend/post_processing/jobs.py
@@ -37,5 +37,5 @@ EVENT_PIPELINE = CompositeProcessor([
 
 
 @job
-def process_event(data):
+def process_event_data(data):
 	EVENT_PIPELINE.process(data)

--- a/zql-backend/scripts/seed.py
+++ b/zql-backend/scripts/seed.py
@@ -2,16 +2,13 @@ import requests
 
 submissions = []
 
-
-requests.post('http://localhost:2420/create_user', json={'username': 'editor', 'password': 'minecraft', 'permission': 0})
-requests.post('http://localhost:2420/create_user', json={'username': 'writer', 'password': 'minecraft', 'permission': 1})
-requests.post('http://localhost:2420/create_user', json={'username': 'reader', 'password': 'minecraft', 'permission': 2})
-
 for i in range(10):
     submissions.extend([
         'diagnosed pranav{} with cancer'.format(chr(65+i)),
         'performed chemotherapy on pranav{}'.format(chr(65+i)),
     ])
 
+user_headers = {'User.Username': 'house', 'User.Permission': 1}
+
 for submission in submissions:
-    requests.post('http://localhost:2015/event', json={'raw': submission})
+    requests.post('http://localhost:2015/event', json={'input': submission}, headers=user_headers)

--- a/zql-frontend/state/textInput.js
+++ b/zql-frontend/state/textInput.js
@@ -157,13 +157,13 @@ function updateSearchValue(searchValue) {
 }
 
 function submitEvent(plainText) {
-  const data = {raw: plainText.toLowerCase()};
+  const data = {input: plainText.toLowerCase()};
   return (dispatch) => new Requestor(BASE_URL).post(EVENT_ROUTE, data)
     .then(json => dispatch(receiveEventResult(json)));
 }
 
 function fetchAnnotation(plainText) {
-  const data = {raw: plainText.toLowerCase()};
+  const data = {input: plainText.toLowerCase()};
   return (dispatch) => new Requestor(BASE_URL).post(ANNOTATION_ROUTE, data)
     .then(json => dispatch(receiveAnnotation(json)));
 }


### PR DESCRIPTION
- allow for non-matching submissions
- persist `author` for events
- limit the output scope for normal and predicted events
- return authored events alongside tagged events for `/events` endpoint
